### PR TITLE
fixed github repo url + tinytiny typo

### DIFF
--- a/config/_default/languages.en.toml
+++ b/config/_default/languages.en.toml
@@ -15,7 +15,7 @@ title = "jonasg.io "
    image = "img/author.png"
    headline = "Software Developer"
    links = [
-     { github = "https://github.com/jonasgeiregat" },
+     { github = "https://github.com/jonas-grgt" },
      { linkedin = "https://www.linkedin.com/in/jonas-geiregat-a8421a31" },
      { twitter = "https://twitter.com/jonas_grgt" },
    ]

--- a/content/posts/object-mother/index.md
+++ b/content/posts/object-mother/index.md
@@ -212,7 +212,7 @@ matter for your test.
 
 ```java
 InvoiceMother.invoice()
-    .withShippingAddress(AddressMother.addres()
+    .withShippingAddress(AddressMother.address()
         .withCountry(Country.US)
         .build())
     .build();


### PR DESCRIPTION
Hey Jonas, just watched your devoxx recording on YT (Your tests also need some architecting)

- then i read your posting.
- then i eagleeyedly spotted this missing s
- then i did not find your github repo (as it has changed from ``jonasgeiregat`` to ``jonas-grgt``)
- then i found it and commited this 's'
- then i realized i could maybe change the linked ghub repo URL, too

Have phun with it (the 's') and keep up the nice talk(ing)s!

cheers